### PR TITLE
Fixed calculation of alternating sign of the jacobian augmentation update step

### DIFF
--- a/cleverhans_tutorials/mnist_blackbox.py
+++ b/cleverhans_tutorials/mnist_blackbox.py
@@ -169,7 +169,7 @@ def train_sub(sess, x, y, bbox_preds, x_sub, y_sub, nb_classes,
     if rho < data_aug - 1:
       print("Augmenting substitute training data.")
       # Perform the Jacobian augmentation
-      lmbda_coef = 2 * int(int(rho / 3) != 0) - 1
+      lmbda_coef = 2*int(int(rho/3)%2==0)-1
       x_sub = jacobian_augmentation(sess, x, x_sub, y_sub, grads,
                                     lmbda_coef * lmbda, aug_batch_size)
 


### PR DESCRIPTION
This fixes a bug in the calculation introduced in [4774fe5324742ffa915ddf676992a2f246e6ed26](https://github.com/tensorflow/cleverhans/commit/4774fe5324742ffa915ddf676992a2f246e6ed26)
that caused the sign to be negative during the first 3 jbda epochs and positive afterwards instead of alternating every 3 epochs.