### PR TITLE
fix CarliniWagnerL2 dtype bug

### DIFF
--- a/cleverhans/tf2/attacks/carlini_wagner_l2.py
+++ b/cleverhans/tf2/attacks/carlini_wagner_l2.py
@@ -124,11 +124,13 @@ class CarliniWagnerL2(object):
                     f"The input is greater than the maximum value of {self.clip_max}!"
                 )
 
-        y, _ = get_or_guess_labels(self.model_fn, x, y=self.y, targeted=self.targeted)
-
         # cast to tensor if provided as numpy array
         original_x = tf.cast(x, tf.float32)
         shape = original_x.shape
+
+        y, _ = get_or_guess_labels(
+            self.model_fn, original_x, y=self.y, targeted=self.targeted
+        )
 
         if not y.shape.as_list()[0] == original_x.shape.as_list()[0]:
             raise CarliniWagnerL2Exception("x and y do not have the same shape!")


### PR DESCRIPTION
I found a bug that causes a crash when the provided `x` array in the CarliniWagnerL2 attack is of dtype float64. The float64 dtype is propagated to `y` by the util function `get_or_guess_labels`. Since `x` is casted to `float32`afterwards, this causes a type mismatch during optimization.

I trivially solved this by moving the cast operation upwards which does not have any other effect but prevents the above bug.