### PR TITLE
Update fast_gradient_method.py

### DIFF
--- a/cleverhans/jax/attacks/fast_gradient_method.py
+++ b/cleverhans/jax/attacks/fast_gradient_method.py
@@ -1,6 +1,6 @@
 import jax.numpy as np
 from jax import grad, vmap
-from jax.experimental.stax import logsoftmax
+from jax.example_libraries.stax import logsoftmax
 
 from cleverhans.jax.utils import one_hot
 


### PR DESCRIPTION
The lastest Stax in JAX should be jax.example_libraries.stax as documented here:
https://jax.readthedocs.io/en/latest/jax.example_libraries.stax.html